### PR TITLE
Make ClusterSync controller count errors

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	hiveinternal "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -119,6 +121,12 @@ func main() {
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Add hiveinternal schemes to manager
+	if err := hiveinternal.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "Failed to add hiveinternal to Scheme")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/openshift/hive-health-operator
 go 1.16
 
 require (
+	github.com/go-logr/logr v0.4.0
+	github.com/google/go-cmp v0.5.2
 	github.com/openshift/hive/apis v0.0.0-20210624144808-697460baf215
 	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.6.1
 	k8s.io/api v0.20.8
 	k8s.io/apimachinery v0.20.8
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,9 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v0.3.0 h1:q4c+kbcR0d5rSurhBR8dIgieOaYpXtsdTYfx22Cu6rs=
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.2.0 h1:v6Ji8yBW77pva6NkJKQdHLAJKrIJKRHz0RXwPqCHSR4=

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -2,29 +2,22 @@ package clustersync
 
 import (
 	"context"
+	"fmt"
 
-	openshifthive "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hiveinternal "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 )
 
 var log = logf.Log.WithName("controller_clustersync")
-
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
 
 // Add creates a new ClusterSync Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -46,17 +39,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource ClusterSync
-	err = c.Watch(&source.Kind{Type: &openshifthive.ClusterSync{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
-	}
-
-	// TODO(user): Modify this to be the types you create that are owned by the primary resource
-	// Watch for changes to secondary resource Pods and requeue the owner ClusterSync
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &openshifthive.ClusterSync{},
-	})
+	err = c.Watch(&source.Kind{Type: &hiveinternal.ClusterSync{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
@@ -75,10 +58,7 @@ type ReconcileClusterSync struct {
 	scheme *runtime.Scheme
 }
 
-// Reconcile reads that state of the cluster for a ClusterSync object and makes changes based on the state read
-// and what is in the ClusterSync.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
-// a Pod as an example
+// Reconcile analyzes ClusterSync objects in all namespaces and reports on failures.
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
@@ -87,67 +67,17 @@ func (r *ReconcileClusterSync) Reconcile(context context.Context, request reconc
 	reqLogger.Info("Reconciling ClusterSync")
 
 	// Fetch the ClusterSync instance
-	instance := &openshifthive.ClusterSync{}
+	instance := &hiveinternal.ClusterSync{}
 	err := r.client.Get(context, request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		reqLogger.Error(err, fmt.Sprintf("Failed to retrieve ClusterSync %s/%s", request.Namespace, request.Name))
 		return reconcile.Result{}, err
 	}
 
-	// Define a new Pod object
-	pod := newPodForCR(instance)
-
-	// Set ClusterSync instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Check if this Pod already exists
-	found := &corev1.Pod{}
-	err = r.client.Get(context, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
-	if err != nil && errors.IsNotFound(err) {
-		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-		err = r.client.Create(context, pod)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		// Pod created successfully - don't requeue
-		return reconcile.Result{}, nil
-	} else if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Pod already exists - don't requeue
-	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
-	return reconcile.Result{}, nil
-}
-
-// newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *openshifthive.ClusterSync) *corev1.Pod {
-	labels := map[string]string{
-		"app": cr.Name,
-	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-pod",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "busybox",
-					Image:   "busybox",
-					Command: []string{"sleep", "3600"},
-				},
-			},
-		},
-	}
+	return reconcile.Result{}, countErrors(instance, reqLogger)
 }

--- a/pkg/controller/clustersync/failure_counter.go
+++ b/pkg/controller/clustersync/failure_counter.go
@@ -1,0 +1,83 @@
+package clustersync
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+
+	hiveinternal "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+)
+
+var failures struct {
+	mutex sync.RWMutex
+	// statuses is a map, keyed by "$namespace/[s]ss/$syncsetname", of pointers to SyncStatus
+	statuses map[string]*hiveinternal.SyncStatus
+	// byNamespace is a map, keyed by "$namespace", of `statuses` keys
+	byNamespace map[string][]string
+}
+
+func init() {
+	failures.statuses = make(map[string]*hiveinternal.SyncStatus)
+	failures.byNamespace = make(map[string][]string)
+}
+
+// failureKey generates a unique string used to key into the `failures.statuses` map.
+func key(ns, ssOrsss string, status *hiveinternal.SyncStatus) string {
+	// The ClusterSync has the same namespace/name as the corresponding ClusterDeployment
+	return fmt.Sprintf("%s/%s/%s", ns, ssOrsss, status.Name)
+}
+
+// recordFailures modifies `failures`, removing any successes and ensuring any failures are present.
+// Must be under lock.
+func recordFailures(ns, ssOrsss string, status *hiveinternal.SyncStatus) error {
+	if status.Result == hiveinternal.FailureSyncSetResult {
+		k := key(ns, ssOrsss, status)
+		failures.statuses[k] = status
+		failures.byNamespace[ns] = append(failures.byNamespace[ns], k)
+	}
+	return nil
+}
+
+func countErrors(cs *hiveinternal.ClusterSync, logger logr.Logger) error {
+	// Since we're using globals, synchronize for multiple controller threads
+	failures.mutex.Lock()
+	defer failures.mutex.Unlock()
+
+	ns := cs.GetNamespace()
+
+	// Start by wiping out all entries associated with this namespace. This is as opposed
+	// to removing entries that have succeeded -- that would miss removing entries for
+	// syncsets that have been deleted and are no longer in the ClusterSync.
+	if byNamespace, ok := failures.byNamespace[ns]; ok {
+		for _, statusKey := range byNamespace {
+			delete(failures.statuses, statusKey)
+		}
+	}
+	failures.byNamespace[ns] = make([]string, 0)
+
+	ssOrsss := "sss"
+	// Process selectorSyncSets
+	for _, s := range cs.Status.SelectorSyncSets {
+		scopy := s.DeepCopy()
+		if err := recordFailures(ns, ssOrsss, scopy); err != nil {
+			logger.Error(err, "")
+		}
+	}
+	ssOrsss = "ss"
+	// Process syncSets
+	for _, s := range cs.Status.SyncSets {
+		scopy := s.DeepCopy()
+		if err := recordFailures(ns, ssOrsss, scopy); err != nil {
+			logger.Error(err, "")
+		}
+	}
+
+	// No need to leak namespace keys
+	// FIXME: But we still could, when a namespace is deleted.
+	if len(failures.byNamespace[ns]) == 0 {
+		delete(failures.byNamespace, ns)
+	}
+
+	return nil
+}

--- a/pkg/controller/clustersync/failure_counter_test.go
+++ b/pkg/controller/clustersync/failure_counter_test.go
@@ -1,0 +1,112 @@
+package clustersync
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	testifyassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hiveinternal "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+)
+
+func assertEqual(t *testing.T, x, y interface{}) {
+	testifyassert.Empty(t, cmp.Diff(x, y), "+actual, -expected")
+}
+
+func mkSyncStatus(name string, result hiveinternal.SyncSetResult) hiveinternal.SyncStatus {
+	return hiveinternal.SyncStatus{
+		Name:   name,
+		Result: result,
+	}
+}
+
+func mkClusterSync(ssStatuses []hiveinternal.SyncStatus, sssStatuses []hiveinternal.SyncStatus) hiveinternal.ClusterSync {
+	cs := hiveinternal.ClusterSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+	}
+	cs.Status.SyncSets = ssStatuses
+	cs.Status.SelectorSyncSets = sssStatuses
+	return cs
+}
+
+func Test_countErrors(t *testing.T) {
+	successStatus1 := mkSyncStatus("good1", hiveinternal.SuccessSyncSetResult)
+	successStatus2 := mkSyncStatus("good2", hiveinternal.SuccessSyncSetResult)
+	failStatus1 := mkSyncStatus("bad1", hiveinternal.FailureSyncSetResult)
+	failStatus2 := mkSyncStatus("bad2", hiveinternal.FailureSyncSetResult)
+
+	type args struct {
+		cs *hiveinternal.ClusterSync
+	}
+	tests := []struct {
+		name                string
+		cs                  hiveinternal.ClusterSync
+		expectedStatuses    map[string]*hiveinternal.SyncStatus
+		expectedByNamespace map[string][]string
+		wantErr             bool
+	}{
+		{
+			name:                "Empty ClusterSync",
+			cs:                  mkClusterSync([]hiveinternal.SyncStatus{}, []hiveinternal.SyncStatus{}),
+			expectedStatuses:    map[string]*hiveinternal.SyncStatus{},
+			expectedByNamespace: map[string][]string{},
+		},
+		{
+			name:                "No erroring syncsets",
+			cs:                  mkClusterSync([]hiveinternal.SyncStatus{successStatus1}, []hiveinternal.SyncStatus{successStatus2}),
+			expectedStatuses:    map[string]*hiveinternal.SyncStatus{},
+			expectedByNamespace: map[string][]string{},
+		},
+		{
+			name: "Failing syncsets",
+			cs: mkClusterSync(
+				[]hiveinternal.SyncStatus{failStatus1, failStatus2},
+				[]hiveinternal.SyncStatus{successStatus1, successStatus2},
+			),
+			expectedStatuses: map[string]*hiveinternal.SyncStatus{
+				"foo/ss/bad1": &failStatus1,
+				"foo/ss/bad2": &failStatus2,
+			},
+			expectedByNamespace: map[string][]string{"foo": {"foo/ss/bad1", "foo/ss/bad2"}},
+		},
+		{
+			name: "Failing selectorsyncsets",
+			cs: mkClusterSync(
+				[]hiveinternal.SyncStatus{successStatus1, successStatus2},
+				[]hiveinternal.SyncStatus{failStatus1, failStatus2},
+			),
+			expectedStatuses: map[string]*hiveinternal.SyncStatus{
+				"foo/sss/bad1": &failStatus1,
+				"foo/sss/bad2": &failStatus2,
+			},
+			expectedByNamespace: map[string][]string{"foo": {"foo/sss/bad1", "foo/sss/bad2"}},
+		},
+		{
+			name: "One of each failing",
+			cs: mkClusterSync(
+				[]hiveinternal.SyncStatus{successStatus1, failStatus1},
+				[]hiveinternal.SyncStatus{failStatus2, successStatus2},
+			),
+			expectedStatuses: map[string]*hiveinternal.SyncStatus{
+				"foo/ss/bad1": &failStatus1,
+				"foo/sss/bad2": &failStatus2,
+			},
+			expectedByNamespace: map[string][]string{"foo": {"foo/sss/bad2", "foo/ss/bad1"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// NOTE: By not cleaning out the globals between tests, we're exercising
+			// idempotence to some extent as well.
+			// TODO: Expect synchronization errors if running multiple test cases in parallel.
+			if err := countErrors(&tt.cs, log); (err != nil) != tt.wantErr {
+				t.Errorf("countErrors() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assertEqual(t, tt.expectedStatuses, failures.statuses)
+			assertEqual(t, tt.expectedByNamespace, failures.byNamespace)
+		})
+	}
+}


### PR DESCRIPTION
Save synchronized global maps of erroring (selector)syncsets that can be looked through later to generate alerts.