### PR TITLE
Async alert loop; Filter by age

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/hive-health-operator/pkg/apis"
 	"github.com/openshift/hive-health-operator/pkg/controller"
+	"github.com/openshift/hive-health-operator/pkg/controller/clustersync"
 	"github.com/openshift/hive-health-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -140,6 +141,10 @@ func main() {
 	addMetrics(ctx, cfg)
 
 	log.Info("Starting the Cmd.")
+
+	// Start the alerter
+	// TODO: Stop this gracefully on termination?
+	go clustersync.AlertLoop()
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -84,10 +84,5 @@ func (r *ReconcileClusterSync) Reconcile(context context.Context, request reconc
 		return reconcile.Result{}, err
 	}
 
-	if err := processAlerts(reqLogger); err != nil {
-		reqLogger.Error(err, "error sending alerts")
-		return reconcile.Result{}, err
-	}
-
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
This commit does two things:
- Moves alerting into a goroutine that fires on an interval. Currently that interval is hardcoded to 1m; ultimately it should be made
configurable via HiveHealthConfig.
- Adds filtering by the age of the sync failure, currently hardcoded to 4h; ultimately this should also be made configurable via
HiveHealthConfig.

I tracked the duplicated/garbled messaging in the previous commit down to what can only be a bug in the logger code. I didn't get further than that; but I refactored to work around it (putting all the text in the message body rather than using the key/values). This will be n/a when this code is replaced with real alerting anyway.